### PR TITLE
Implement request #20940: Information about recently created signature

### DIFF
--- a/Crypt/GPG/SignatureCreationInfo.php
+++ b/Crypt/GPG/SignatureCreationInfo.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Part of Crypt_GPG
+ *
+ * PHP version 5
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Christian Weiske <cweiske@php.net>
+ * @copyright 2015 PEAR
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @version   CVS: $Id$
+ * @link      http://pear.php.net/package/Crypt_GPG
+ * @link      http://pear.php.net/manual/en/package.encryption.crypt-gpg.php
+ * @link      http://www.gnupg.org/
+ */
+
+/**
+ * Information about a recently created signature.
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Christian Weiske <cweiske@php.net>
+ * @copyright 2015 PEAR
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @link      http://pear.php.net/package/Crypt_GPG
+ * @link      http://pear.php.net/manual/en/package.encryption.crypt-gpg.php
+ * @link      http://www.gnupg.org/
+ */
+class Crypt_GPG_SignatureCreationInfo
+{
+    /**
+     * One of the three signature types:
+     * - {@link Crypt_GPG::SIGN_MODE_NORMAL}
+     * - {@link Crypt_GPG::SIGN_MODE_CLEAR}
+     * - {@link Crypt_GPG::SIGN_MODE_DETACHED}
+     *
+     * @var integer
+     */
+    protected $mode;
+
+    /**
+     * Public Key algorithm
+     *
+     * @var integer
+     */
+    protected $pkAlgorithm;
+
+    /**
+     * Algorithm to hash the data
+     *
+     * @see RFC 2440 / 9.4. Hash Algorithm
+     * @var integer
+     */
+    protected $hashAlgorithm;
+
+    /**
+     * OpenPGP signature class
+     *
+     * @var mixed
+     */
+    protected $class;
+
+    /**
+     * Unix timestamp when the signature was created
+     *
+     * @var integer
+     */
+    protected $timestamp;
+
+    /**
+     * Key fingerprint
+     *
+     * @var string
+     */
+    protected $keyFingerprint;
+
+    /**
+     * If the line given to the constructor was valid
+     *
+     * @var boolean
+     */
+    protected $valid;
+
+    /**
+     * Names for the hash algorithm IDs.
+     *
+     * Names taken from RFC 3156, without the leading "pgp-".
+     *
+     * @see RFC 2440 / 9.4. Hash Algorithm
+     * @see RFC 3156 / 5. OpenPGP signed data
+     * @var array
+     */
+    protected static $hashAlgorithmNames = array(
+        1 => 'md5',
+        2 => 'sha1',
+        3 => 'ripemd160',
+        5 => 'md2',
+        6 => 'tiger192',
+        7 => 'haval-5-160',
+    );
+
+    /**
+     * Parse a SIG_CREATED line from gnupg
+     *
+     * @param string $sigCreatedLine Line beginning with "SIG_CREATED "
+     */
+    public function __construct($sigCreatedLine = null)
+    {
+        if ($sigCreatedLine === null) {
+            $this->valid = false;
+            return;
+        }
+
+        $parts = explode(' ', $sigCreatedLine);
+        if (count($parts) !== 7) {
+            $this->valid = false;
+            return;
+        }
+        list(
+            $title, $mode, $pkAlgorithm, $hashAlgorithm,
+            $class, $timestamp, $keyFingerprint
+        ) = $parts;
+
+        switch (strtoupper($mode[0])) {
+        case 'D':
+            $this->mode = Crypt_GPG::SIGN_MODE_DETACHED;
+            break;
+        case 'C':
+            $this->mode = Crypt_GPG::SIGN_MODE_CLEAR;
+            break;
+        case 'S':
+            $this->mode = Crypt_GPG::SIGN_MODE_NORMAL;
+            break;
+        }
+
+        $this->pkAlgorithm    = (int) $pkAlgorithm;
+        $this->hashAlgorithm  = (int) $hashAlgorithm;
+        $this->class          = $class;
+        if (is_numeric($timestamp)) {
+            $this->timestamp  = (int) $timestamp;
+        } else {
+            $this->timestamp  = strtotime($timestamp);
+        }
+        $this->keyFingerprint = $keyFingerprint;
+        $this->valid = true;
+    }
+
+    /**
+     * Get the signature type
+     * - {@link Crypt_GPG::SIGN_MODE_NORMAL}
+     * - {@link Crypt_GPG::SIGN_MODE_CLEAR}
+     * - {@link Crypt_GPG::SIGN_MODE_DETACHED}
+     *
+     * @return integer
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Return the public key algorithm used.
+     *
+     * @return integer
+     */
+    public function getPkAlgorithm()
+    {
+        return $this->pkAlgorithm;
+    }
+
+    /**
+     * Return the hash algorithm used to hash the data to sign.
+     *
+     * @return integer
+     */
+    public function getHashAlgorithm()
+    {
+        return $this->hashAlgorithm;
+    }
+
+    /**
+     * Get a name for the used hashing algorithm.
+     *
+     * @return string|null
+     */
+    public function getHashAlgorithmName()
+    {
+        if (!isset(self::$hashAlgorithmNames[$this->hashAlgorithm])) {
+            return null;
+        }
+        return self::$hashAlgorithmNames[$this->hashAlgorithm];
+    }
+
+    /**
+     * Return the timestamp at which the signature was created
+     *
+     * @return integer
+     */
+    public function getTimestamp()
+    {
+        return $this->timestamp;
+    }
+
+    /**
+     * Return the key's fingerprint
+     *
+     * @return string
+     */
+    public function getKeyFingerprint()
+    {
+        return $this->keyFingerprint;
+    }
+
+    /**
+     * Tell if the fingerprint line given to the constructor was valid
+     *
+     * @return boolean
+     */
+    public function isValid()
+    {
+        return $this->valid;
+    }
+}
+?>

--- a/package.xml
+++ b/package.xml
@@ -66,6 +66,7 @@ This release makes the mbstring extension a required dependency as the assuan pr
      </file>
      <file baseinstalldir="/" name="ProcessControl.php" role="php" />
      <file baseinstalldir="/" name="Signature.php" role="php" />
+     <file baseinstalldir="/" name="SignatureCreationInfo.php" role="php" />
      <file baseinstalldir="/" name="SubKey.php" role="php" />
      <file baseinstalldir="/" name="UserId.php" role="php" />
      <file baseinstalldir="/" name="VerifyStatusHandler.php" role="php" />
@@ -124,6 +125,7 @@ This release makes the mbstring extension a required dependency as the assuan pr
     <file baseinstalldir="/" name="KeyTest.php" role="test" />
     <file baseinstalldir="/" name="SignatureTest.php" role="test" />
     <file baseinstalldir="/" name="SignTest.php" role="test" />
+    <file baseinstalldir="/" name="SignatureCreationInfoTest.php" role="test" />
     <file baseinstalldir="/" name="SubKeyTest.php" role="test" />
     <file baseinstalldir="/" name="TestCase.php" role="test" />
     <file baseinstalldir="/" name="UserIdTest.php" role="test" />

--- a/tests/SignTest.php
+++ b/tests/SignTest.php
@@ -609,6 +609,26 @@ class SignTestCase extends Crypt_GPG_TestCase
     }
 
     // }}}
+    // {{{ testGetLastSignatureInfo()
+
+    public function testGetLastSignatureInfo()
+    {
+        $this->gpg->addSignKey('first-keypair@example.com', 'test1');
+        $signedData = $this->gpg->sign('test', Crypt_GPG::SIGN_MODE_DETACHED);
+
+        $sigInfo = $this->gpg->getLastSignatureInfo();
+        $this->assertInstanceOf('Crypt_GPG_SignatureCreationInfo', $sigInfo);
+        $this->assertTrue($sigInfo->isValid());
+        $this->assertEquals(date('Y-m-d'), date('Y-m-d', $sigInfo->getTimestamp()));
+        $this->assertEquals(Crypt_GPG::SIGN_MODE_DETACHED, $sigInfo->getMode());
+        $this->assertEquals(
+            '8D2299D9C5C211128B32BBB0C097D9EC94C06363',
+            $sigInfo->getKeyFingerprint()
+        );
+        $this->assertNotNull($sigInfo->getHashAlgorithmName());
+    }
+
+    // }}}
 }
 
 ?>

--- a/tests/SignatureCreationInfoTest.php
+++ b/tests/SignatureCreationInfoTest.php
@@ -1,0 +1,76 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * Unit tests for Crypt_GPG
+ *
+ * LICENSE:
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2005-2008 silverorange
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @version   CVS: $Id$
+ * @link      http://pear.php.net/package/Crypt_GPG
+ */
+
+/**
+ * Base test case.
+ */
+require_once 'TestCase.php';
+
+//require_once 'Crypt/GPG/SignatureCreationInfo.php';
+
+/**
+ * Test the signature creation information class
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Michael Gauthier <mike@silverorange.com>
+ * @copyright 2005-2008 silverorange
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @link      http://pear.php.net/package/Crypt_GPG
+ */
+class SignatureCreationInfoTest extends Crypt_GPG_TestCase
+{
+
+    public function testValidSigCreatedLine()
+    {
+        $sci = new Crypt_GPG_SignatureCreationInfo(
+            'SIG_CREATED D 17 2 00 1440922957 8D2299D9C5C211128B32BBB0C097D9EC94C06363'
+        );
+        $this->assertTrue($sci->isValid());
+        $this->assertEquals(Crypt_GPG::SIGN_MODE_DETACHED, $sci->getMode());
+        $this->assertEquals(1440922957, $sci->getTimestamp());
+        $this->assertEquals(17, $sci->getPkAlgorithm());
+        $this->assertEquals(2, $sci->getHashAlgorithm());
+        $this->assertEquals('sha1', $sci->getHashAlgorithmName());
+        $this->assertEquals(
+            '8D2299D9C5C211128B32BBB0C097D9EC94C06363',
+            $sci->getKeyFingerprint()
+        );
+    }
+
+    public function testInvalidSigCreatedLine()
+    {
+        $sci = new Crypt_GPG_SignatureCreationInfo('foo bar');
+        $this->assertNull($sci->getMode());
+        $this->assertFalse($sci->isValid());
+    }
+}
+?>


### PR DESCRIPTION
We store information about the most recently created signature
and provide an object to work with this information.

The hash algorithm in this information is needed to implement
RFC 2015 and RFC 3156 (PGP-encrypted MIME emails).

https://pear.php.net/bugs/20940