### PR TITLE
Add non-implemented SETKEYINFO PinEntry command

### DIFF
--- a/Crypt/GPG/PinEntry.php
+++ b/Crypt/GPG/PinEntry.php
@@ -451,6 +451,7 @@ class Crypt_GPG_PinEntry
         case 'SETCANCEL':
         case 'SETQUALITYBAR':
         case 'SETQUALITYBAR_TT':
+        case 'SETKEYINFO':
         case 'OPTION':
             return $this->sendNotImplementedOK();
 

--- a/scripts/crypt-gpg-pinentry
+++ b/scripts/crypt-gpg-pinentry
@@ -16,7 +16,7 @@ if ($path[0] === '@') {
 }
 
 // Workaround for composer installs (#19914)
-$composerDir = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Console_CommandLine';
+$composerDir = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
 if (is_dir($composerDir)) {
     $path .= PATH_SEPARATOR . $composerDir;
 }


### PR DESCRIPTION
Add non-implemented SETKEYINFO PinEntry command so decrypt doesn't hang in certain cases.  

Simple text decrypt functions were hanging.  When I was able to get into the PinEntry logs, I noticed it was hung on a SETKEYINFO command.  Once I added this line into the non-implemented command section of the PinEntry commands, the decrypt function didn't hang anymore and successfully decrypted the text.