### PR TITLE
fix incorrect fsf address

### DIFF
--- a/Crypt/GPG.php
+++ b/Crypt/GPG.php
@@ -40,8 +40,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/ByteUtils.php
+++ b/Crypt/GPG/ByteUtils.php
@@ -22,8 +22,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/DecryptStatusHandler.php
+++ b/Crypt/GPG/DecryptStatusHandler.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/Engine.php
+++ b/Crypt/GPG/Engine.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/Exceptions.php
+++ b/Crypt/GPG/Exceptions.php
@@ -25,8 +25,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/Key.php
+++ b/Crypt/GPG/Key.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/KeyGenerator.php
+++ b/Crypt/GPG/KeyGenerator.php
@@ -22,8 +22,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/KeyGeneratorErrorHandler.php
+++ b/Crypt/GPG/KeyGeneratorErrorHandler.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/KeyGeneratorStatusHandler.php
+++ b/Crypt/GPG/KeyGeneratorStatusHandler.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/PinEntry.php
+++ b/Crypt/GPG/PinEntry.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/ProcessControl.php
+++ b/Crypt/GPG/ProcessControl.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/Signature.php
+++ b/Crypt/GPG/Signature.php
@@ -22,8 +22,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/SubKey.php
+++ b/Crypt/GPG/SubKey.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/UserId.php
+++ b/Crypt/GPG/UserId.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPG/VerifyStatusHandler.php
+++ b/Crypt/GPG/VerifyStatusHandler.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/Crypt/GPGAbstract.php
+++ b/Crypt/GPGAbstract.php
@@ -29,8 +29,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/package.php
+++ b/package.php
@@ -20,8 +20,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/DecryptAndVerifyTest.php
+++ b/tests/DecryptAndVerifyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/DecryptTest.php
+++ b/tests/DecryptTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/DeletePrivateKeyTest.php
+++ b/tests/DeletePrivateKeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/DeletePublicKeyTest.php
+++ b/tests/DeletePublicKeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/EncryptAndSignTest.php
+++ b/tests/EncryptAndSignTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/EncryptTest.php
+++ b/tests/EncryptTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/ExceptionsTest.php
+++ b/tests/ExceptionsTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/ExportPublicKeyTest.php
+++ b/tests/ExportPublicKeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/GeneralTest.php
+++ b/tests/GeneralTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/GetFingerprintTest.php
+++ b/tests/GetFingerprintTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/GetKeysTest.php
+++ b/tests/GetKeysTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/ImportKeyTest.php
+++ b/tests/ImportKeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/KeyGeneratorTest.php
+++ b/tests/KeyGeneratorTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/KeyTest.php
+++ b/tests/KeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/SignTest.php
+++ b/tests/SignTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/SignatureCreationInfoTest.php
+++ b/tests/SignatureCreationInfoTest.php
@@ -17,8 +17,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/SignatureTest.php
+++ b/tests/SignatureTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/SubKeyTest.php
+++ b/tests/SubKeyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,8 +23,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/UserIdTest.php
+++ b/tests/UserIdTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG

--- a/tests/VerifyTest.php
+++ b/tests/VerifyTest.php
@@ -28,8 +28,8 @@
  * Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
  *
  * @category  Encryption
  * @package   Crypt_GPG


### PR DESCRIPTION
The address have change (59 Temple Place => 51 Franklin Street)

The common practice is to only give URL in file headers
The full physical address is in the LICENSE file.