### PR TITLE
Console_CommandLine folder reference for composer should be lowercase

### DIFF
--- a/scripts/crypt-gpg-pinentry
+++ b/scripts/crypt-gpg-pinentry
@@ -16,7 +16,7 @@ if ($path[0] === '@') {
 }
 
 // Workaround for composer installs (#19914)
-$composerDir = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Console_CommandLine';
+$composerDir = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
 if (is_dir($composerDir)) {
     $path .= PATH_SEPARATOR . $composerDir;
 }

--- a/scripts/crypt-gpg-pinentry
+++ b/scripts/crypt-gpg-pinentry
@@ -15,10 +15,16 @@ if ($path[0] === '@') {
     // in a local PEAR tree that's not in the system PHP include path.
 }
 
-// Workaround for composer installs (#19914)
-$composerDir = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
-if (is_dir($composerDir)) {
-    $path .= PATH_SEPARATOR . $composerDir;
+// Workaround for composer installs (#19914).  Path used if installed via composer using PEAR as a repository.
+$composerDir_pear = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Console_CommandLine';
+if (is_dir($composerDir_pear)) {
+    $path .= PATH_SEPARATOR . $composerDir_pear;
+}
+
+//Path if installed via composer without supplying a repository
+$composerDir_composer = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
+if (is_dir($composerDir_composer)) {
+    $path .= PATH_SEPARATOR . $composerDir_composer;
 }
 
 // We depend on Console_CommandLine, so we append also the default include path

--- a/scripts/crypt-gpg-pinentry
+++ b/scripts/crypt-gpg-pinentry
@@ -16,15 +16,15 @@ if ($path[0] === '@') {
 }
 
 // Workaround for composer installs (#19914).  Path used if installed via composer using PEAR as a repository.
-$composerDir_pear = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Console_CommandLine';
-if (is_dir($composerDir_pear)) {
-    $path .= PATH_SEPARATOR . $composerDir_pear;
+$composerDirForPearRepository = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Console_CommandLine';
+if (is_dir($composerDirForPearRepository)) {
+    $path .= PATH_SEPARATOR . $composerDirForPearRepository;
 }
 
-//Path if installed via composer without supplying a repository
-$composerDir_composer = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
-if (is_dir($composerDir_composer)) {
-    $path .= PATH_SEPARATOR . $composerDir_composer;
+// Path if installed via composer without supplying a repository.
+$composerDirForComposer = $path . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'console_commandline';
+if (is_dir($composerDirForComposer)) {
+    $path .= PATH_SEPARATOR . $composerDirForComposer;
 }
 
 // We depend on Console_CommandLine, so we append also the default include path


### PR DESCRIPTION
I'm splitting off this additional issue from #18 as it is a different issue.

@alecpl - Composer's folder structure is determined by the name of the package.  Since the name of the package we're trying to reference here is pear/console_commandline, our composer folder structure should also be lowercase.  This change should only affect people using composer since anyone using pear should already have the Command_ConsoleLine class in their include path.  I hope that helps.

![image](https://cloud.githubusercontent.com/assets/1131687/12555532/a44dac6c-c34f-11e5-8aec-56ee15bc1931.png)