### PR TITLE
Add non-implemented SETKEYINFO PinEntry command

### DIFF
--- a/Crypt/GPG/PinEntry.php
+++ b/Crypt/GPG/PinEntry.php
@@ -451,6 +451,7 @@ class Crypt_GPG_PinEntry
         case 'SETCANCEL':
         case 'SETQUALITYBAR':
         case 'SETQUALITYBAR_TT':
+        case 'SETKEYINFO':
         case 'OPTION':
             return $this->sendNotImplementedOK();
 


### PR DESCRIPTION
I just closed PR #18 and opened this instead as I mistakenly added an additional issue to it.  Some of the history can be found there

Add non-implemented SETKEYINFO PinEntry command so decrypt doesn't hang in certain cases.

Simple text decrypt functions were hanging. When I was able to get into the PinEntry logs, I noticed it was hung on a SETKEYINFO command. Once I added this line into the non-implemented command section of the PinEntry commands, the decrypt function didn't hang anymore and successfully decrypted the text.