### PR TITLE
fixed Engine::getVersion not passing agent to new Engine constructor

### DIFF
--- a/Crypt/GPG/Engine.php
+++ b/Crypt/GPG/Engine.php
@@ -960,7 +960,8 @@ class Crypt_GPG_Engine
             $options = array(
                 'homedir' => $this->_homedir,
                 'binary'  => $this->_binary,
-                'debug'   => $this->_debug
+                'debug'   => $this->_debug,
+                'agent'   => $this->_agent,
             );
 
             $engine = new self($options);
@@ -1662,7 +1663,7 @@ class Crypt_GPG_Engine
             );
 
             $agentInfo             = explode(' ', $agentInfo, 3);
-            $this->_agentInfo      = $agentInfo[2];
+            $this->_agentInfo      = isset($agentInfo[2])?$agentInfo[2]:null;
             $env['GPG_AGENT_INFO'] = $this->_agentInfo;
 
             // gpg-agent daemon is started, we can close the launching process

--- a/Crypt/GPG/Engine.php
+++ b/Crypt/GPG/Engine.php
@@ -1663,7 +1663,7 @@ class Crypt_GPG_Engine
             );
 
             $agentInfo             = explode(' ', $agentInfo, 3);
-            $this->_agentInfo      = isset($agentInfo[2])?$agentInfo[2]:null;
+            $this->_agentInfo      = isset($agentInfo[2]) ? $agentInfo[2] : null;
             $env['GPG_AGENT_INFO'] = $this->_agentInfo;
 
             // gpg-agent daemon is started, we can close the launching process


### PR DESCRIPTION
Also added an isset() check to prevent PHP notices due to undefined array offset

See bug report:
https://pear.php.net/bugs/bug.php?id=21034