### PR TITLE
Mark code in README.md as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,17 @@ Please submit pull requests for your bug reports!
 
 ## Testing ##
 To test, run either
-$ phpunit tests/
+`$ phpunit tests/`
   or
-$ pear run-tests -r
+`$ pear run-tests -r`
 
 ## Building ##
 To build, simply
-$ pear package
+`$ pear package`
 
 ## Installing ##
 To install from scratch
-$ pear install package.xml
+`$ pear install package.xml`
 
 To upgrade
-$ pear upgrade -f package.xml
+`$ pear upgrade -f package.xml`


### PR DESCRIPTION
The commands provided in the README weren’t wrapped in Markdown’s `` code back ticks. This fixes that.