### PR TITLE
add POSIX method to isRunning() consistent with terminate()

### DIFF
--- a/Crypt/GPG/ProcessControl.php
+++ b/Crypt/GPG/ProcessControl.php
@@ -100,7 +100,9 @@ class Crypt_GPG_ProcessControl
     {
         $running = false;
 
-        if (PHP_OS === 'WINNT') {
+        if (function_exists('posix_getpgid')) {
+            $running = false !== posix_getpgid($this->pid);
+        } elseif (PHP_OS === 'WINNT') {
             $command = 'tasklist /fo csv /nh /fi '
                 . escapeshellarg('PID eq ' . $this->pid);
 


### PR DESCRIPTION
add POSIX method to isRunning() consistent with terminate(); removes exec() requirement on supporting systems