### PR TITLE
Feature set arguments

### DIFF
--- a/Crypt/GPG.php
+++ b/Crypt/GPG.php
@@ -2045,6 +2045,38 @@ class Crypt_GPG extends Crypt_GPGAbstract
     }
 
     // }}}
+    // {{{ _armor()
+
+    /**
+     * Handle armor argument.
+     *
+     * @param string  $method the method you want to add/remove the armor argument for.
+     * @param boolean $armor  If true, the ASCII armored argument is added;
+     *                        otherwise, it is removed.
+     * 
+     */
+    protected function _armor($method, $armor)
+    {
+        if ($armor) {
+            if (!array_key_exists($method, $this->arguments)) {
+                $this->arguments[$method] = array('--armor');
+            } else {
+                if (!array_search('--armor', $this->arguments[$method])) {
+                    $this->arguments[$method][] = '--armor';
+                }
+            }
+        } else {
+            if (array_key_exists($method, $this->arguments)) {
+                while (
+                    ($key = array_search('--armor', $this->arguments[$method])) !== false
+                )  {
+                    unset($this->arguments[$method][$key]);
+                }
+            }
+        }
+    }
+
+    // }}}
 }
 
 // }}}

--- a/Crypt/GPG.php
+++ b/Crypt/GPG.php
@@ -290,7 +290,7 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function importKey($data)
     {
-        return $this->_importKey($data, false);
+        return $this->_importKey($data, false, $this->getArguments('importKey'));
     }
 
     // }}}
@@ -333,7 +333,7 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function importKeyFile($filename)
     {
-        return $this->_importKey($filename, true);
+        return $this->_importKey($filename, true, $this->getArguments('importKey'));
     }
 
     // }}}
@@ -373,7 +373,8 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function exportPrivateKey($keyId, $armor = true)
     {
-        return $this->_exportKey($keyId, $armor, true);
+        $this->_armor('exportKey', $armor);
+        return $this->_exportKey($keyId, true, $this->arguments['exportKey']);
     }
 
     // }}}
@@ -409,7 +410,8 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function exportPublicKey($keyId, $armor = true)
     {
-        return $this->_exportKey($keyId, $armor, false);
+        $this->_armor('exportKey', $armor);
+        return $this->_exportKey($keyId, false, $this->arguments['exportKey']);
     }
 
     // }}}
@@ -458,13 +460,13 @@ class Crypt_GPG extends Crypt_GPGAbstract
         }
 
         $operation = '--delete-key ' . escapeshellarg($fingerprint);
-        $arguments = array(
+        $this->addArguments('deletePublicKey', array(
             '--batch',
             '--yes'
-        );
+        ));
 
         $this->engine->reset();
-        $this->engine->setOperation($operation, $arguments);
+        $this->engine->setOperation($operation, $this->getArguments('deletePublicKey'));
         $this->engine->run();
     }
 
@@ -508,13 +510,13 @@ class Crypt_GPG extends Crypt_GPGAbstract
         }
 
         $operation = '--delete-secret-key ' . escapeshellarg($fingerprint);
-        $arguments = array(
+        $this->addArguments('deletePrivateKey', array(
             '--batch',
             '--yes'
-        );
+        ));
 
         $this->engine->reset();
-        $this->engine->setOperation($operation, $arguments);
+        $this->engine->setOperation($operation, $this->getArguments('deletePrivateKey'));
         $this->engine->run();
     }
 
@@ -546,7 +548,7 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function getKeys($keyId = '')
     {
-        return parent::_getKeys($keyId);
+        return parent::_getKeys($keyId, $this->getArguments('getKeys'));
     }
 
     // }}}
@@ -586,14 +588,14 @@ class Crypt_GPG extends Crypt_GPGAbstract
     {
         $output    = '';
         $operation = '--list-keys ' . escapeshellarg($keyId);
-        $arguments = array(
+        $this->addArguments('getFingerprint', array(
             '--with-colons',
             '--with-fingerprint'
-        );
+        ));
 
         $this->engine->reset();
         $this->engine->setOutput($output);
-        $this->engine->setOperation($operation, $arguments);
+        $this->engine->setOperation($operation, $this->getArguments('getFingerprint'));
         $this->engine->run();
 
         $fingerprint = null;
@@ -663,7 +665,8 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function encrypt($data, $armor = self::ARMOR_ASCII)
     {
-        return $this->_encrypt($data, false, null, $armor);
+        $this->_armor('encrypt', $armor);
+        return $this->_encrypt($data, false, null, $this->getArguments('encrypt'));
     }
 
     // }}}
@@ -702,7 +705,10 @@ class Crypt_GPG extends Crypt_GPGAbstract
         $encryptedFile = null,
         $armor = self::ARMOR_ASCII
     ) {
-        return $this->_encrypt($filename, true, $encryptedFile, $armor);
+        $this->_armor('encrypt', $armor);
+        return $this->_encrypt(
+          $filename, true, $encryptedFile, $this->getArguments('encrypt')
+        );
     }
 
     // }}}
@@ -742,7 +748,10 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function encryptAndSign($data, $armor = self::ARMOR_ASCII)
     {
-        return $this->_encryptAndSign($data, false, null, $armor);
+        $this->_armor('encryptAndSign', $armor);
+        return $this->_encryptAndSign(
+            $data, false, null, $this->getArguments('encryptAndSign')
+        );
     }
 
     // }}}
@@ -796,7 +805,10 @@ class Crypt_GPG extends Crypt_GPGAbstract
         $signedFile = null,
         $armor = self::ARMOR_ASCII
     ) {
-        return $this->_encryptAndSign($filename, true, $signedFile, $armor);
+        $this->_armor('encryptAndSign', $armor);
+        return $this->_encryptAndSign(
+            $filename, true, $signedFile, $this->getArguments('encryptAndSign')
+        );
     }
 
     // }}}
@@ -830,7 +842,9 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function decrypt($encryptedData)
     {
-        return $this->_decrypt($encryptedData, false, null);
+        return $this->_decrypt(
+            $encryptedData, false, null, $this->getArguments('decrypt')
+        );
     }
 
     // }}}
@@ -873,7 +887,9 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function decryptFile($encryptedFile, $decryptedFile = null)
     {
-        return $this->_decrypt($encryptedFile, true, $decryptedFile);
+        return $this->_decrypt(
+            $encryptedFile, true, $decryptedFile, $this->getArguments('decrypt')
+        );
     }
 
     // }}}
@@ -916,7 +932,13 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function decryptAndVerify($encryptedData, $ignoreVerifyErrors = false)
     {
-        return $this->_decryptAndVerify($encryptedData, false, null, $ignoreVerifyErrors);
+        return $this->_decryptAndVerify(
+            $encryptedData,
+            false,
+            null,
+            $ignoreVerifyErrors,
+            $this->getArguments('decryptAndVerify')
+        );
     }
 
     // }}}
@@ -968,7 +990,13 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function decryptAndVerifyFile($encryptedFile, $decryptedFile = null, $ignoreVerifyErrors = false)
     {
-        return $this->_decryptAndVerify($encryptedFile, true, $decryptedFile, $ignoreVerifyErrors);
+        return $this->_decryptAndVerify(
+            $encryptedFile,
+            true,
+            $decryptedFile,
+            $ignoreVerifyErrors,
+            $this->getArguments('decryptAndVerify')
+        );
     }
 
     // }}}
@@ -1021,7 +1049,10 @@ class Crypt_GPG extends Crypt_GPGAbstract
         $armor = self::ARMOR_ASCII,
         $textmode = self::TEXT_RAW
     ) {
-        return $this->_sign($data, false, null, $mode, $armor, $textmode);
+        $this->_armor('sign', $armor);
+        return $this->_sign(
+            $data, false, null, $mode, $textmode, $this->getArguments('sign')
+        );
     }
 
     // }}}
@@ -1086,13 +1117,14 @@ class Crypt_GPG extends Crypt_GPGAbstract
         $armor = self::ARMOR_ASCII,
         $textmode = self::TEXT_RAW
     ) {
+        $this->_armor('sign', $armor);
         return $this->_sign(
             $filename,
             true,
             $signedFile,
             $mode,
-            $armor,
-            $textmode
+            $textmode,
+            $this->getArguments('sign')
         );
     }
 
@@ -1130,7 +1162,7 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function verify($signedData, $signature = '')
     {
-        return $this->_verify($signedData, false, $signature);
+        return $this->_verify($signedData, false, $signature, $this->getArguments('verify'));
     }
 
     // }}}
@@ -1169,7 +1201,7 @@ class Crypt_GPG extends Crypt_GPGAbstract
      */
     public function verifyFile($filename, $signature = '')
     {
-        return $this->_verify($filename, true, $signature);
+        return $this->_verify($filename, true, $signature, $this->getArguments('verify'));
     }
 
     // }}}

--- a/Crypt/GPG/KeyGenerator.php
+++ b/Crypt/GPG/KeyGenerator.php
@@ -559,11 +559,13 @@ class Crypt_GPG_KeyGenerator extends Crypt_GPGAbstract
 
         $input = implode("\n", $keyParamsFormatted) . "\n%commit\n";
 
+        $this->addArguments('generateKey', array('--batch'));
+
         $this->engine->reset();
         $this->engine->setProcessData('Handle', $handle);
         $this->engine->setInput($input);
         $this->engine->setOutput($output);
-        $this->engine->setOperation('--gen-key', array('--batch'));
+        $this->engine->setOperation('--gen-key', $this->getArguments('generateKey'));
 
         try {
             $this->engine->run();
@@ -591,7 +593,7 @@ class Crypt_GPG_KeyGenerator extends Crypt_GPGAbstract
         }
 
         $fingerprint = $this->engine->getProcessData('KeyCreated');
-        $keys        = $this->_getKeys($fingerprint);
+        $keys        = $this->_getKeys($fingerprint, $this->getArguments('getKeys'));
 
         if (count($keys) === 0) {
             throw new Crypt_GPG_KeyNotCreatedException(

--- a/Crypt/GPGAbstract.php
+++ b/Crypt/GPGAbstract.php
@@ -401,10 +401,11 @@ abstract class Crypt_GPGAbstract
      * {@link http://www.gnupg.org/download/ GPG package} for a detailed
      * description of how the GPG command output is parsed.
      *
-     * @param string $keyId optional. Only keys with that match the specified
-     *                      pattern are returned. The pattern may be part of
-     *                      a user id, a key id or a key fingerprint. If not
-     *                      specified, all keys are returned.
+     * @param string $keyId      optional. Only keys with that match the specified
+     *                           pattern are returned. The pattern may be part of
+     *                           a user id, a key id or a key fingerprint. If not
+     *                           specified, all keys are returned.
+     * @param array  $arguments  user supplied arguments for the operation.
      *
      * @return array an array of {@link Crypt_GPG_Key} objects. If no keys
      *               match the specified <kbd>$keyId</kbd> an empty array is
@@ -416,7 +417,7 @@ abstract class Crypt_GPGAbstract
      *
      * @see Crypt_GPG_Key
      */
-    protected function _getKeys($keyId = '')
+    protected function _getKeys($keyId = '', $arguments)
     {
         // get private key fingerprints
         if ($keyId == '') {
@@ -427,12 +428,12 @@ abstract class Crypt_GPGAbstract
 
         // According to The file 'doc/DETAILS' in the GnuPG distribution, using
         // double '--with-fingerprint' also prints the fingerprint for subkeys.
-        $arguments = array(
+        $arguments = array_merge($arguments, array(
             '--with-colons',
             '--with-fingerprint',
             '--with-fingerprint',
             '--fixed-list-mode'
-        );
+        ));
 
         $output = '';
 

--- a/Crypt/GPGAbstract.php
+++ b/Crypt/GPGAbstract.php
@@ -178,6 +178,15 @@ abstract class Crypt_GPGAbstract
      */
     protected $engine = null;
 
+    /**
+     * Arguments used to control the public methods.
+     *
+     * @var array
+     *
+     * @see Crypt_GPGAbstract::setArguments()
+     */
+    protected $arguments = array();
+
     // }}}
     // {{{ __construct()
 
@@ -304,6 +313,63 @@ abstract class Crypt_GPGAbstract
     public function setEngine(Crypt_GPG_Engine $engine)
     {
         $this->engine = $engine;
+        return $this;
+    }
+
+    // }}}
+    // {{{ setArguments()
+
+    /**
+     * Sets arguments to be used by the several GnuPG operations
+     *
+     * Normally this method does not need to be used. It provides a means for
+     * the experienced user to tweak GnuPG a bit where needed.
+     *
+     * @param string $method    the method you want to set arguments for.
+     * @param array  $arguments the arguments you want to set.
+     *
+     * @return Crypt_GPGAbstract the current object, for fluent interface.
+     */
+    public function setArguments($method, $arguments)
+    {
+        $this->arguments[$method] = $arguments;
+        return $this;
+    }
+
+    // }}}
+    // {{{ getArguments()
+
+    /**
+     * Get arguments to be used by the several GnuPG operations
+     *
+     * Create an empty array if no arguments for the method yet exist.
+     *
+     * @param string $method    the method you want to get arguments for.
+     *
+     * @return array the arguments for the given method.
+     */
+    public function getArguments($method)
+    {
+        if (!array_key_exists($method, $this->arguments)) {
+            $this->arguments[$method] = array();
+        }
+        return $this->arguments[$method];
+    }
+
+    // }}}
+    // {{{ addArguments()
+
+    /**
+     * Add arguments to be used by the several GnuPG operations
+     *
+     * @param string $method    the method you want to set arguments for.
+     * @param array  $arguments the arguments you want to set.
+     *
+     * @return Crypt_GPGAbstract the current object, for fluent interface.
+     */
+    public function addArguments($method, $arguments)
+    {
+        $this->arguments[$method] = array_merge($this->getArguments($method), $arguments);
         return $this;
     }
 


### PR DESCRIPTION
Wouldn't it be nice to allow the user to add GnuPG arguments to all public methods? This pull request adds the public methods setArguments(), addArguments() and getArguments() that do just that.

Next I've removed the armor argument to the protected methods and added the support for the new arguments infrastructure to them. Making sure the removed armor arguments are not needed anymore.

At last I've added the support to the public methods in a nice clean fashion, not breaking current ABI.

The average user can easily ignore this feature and will not notice any difference. The more advanced user can now add extra options at will. The reason I've added this feature is because ever since August 5th 2016 the GnuPG project changed the default for --emit-version. Now users depending on the output of --emit-version are able to once again add them to their output.