### PR TITLE
Compatibility with phpunit >= 6.0

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -75,7 +75,7 @@ require_once 'Crypt/GPG/Signature.php';
  *    A public-private key pair that has multiple encrypting subkeys. The
  *    first subkey is an ELG-E key. The second is an RSA key.
  */
-abstract class Crypt_GPG_TestCase extends PHPUnit_Framework_TestCase
+abstract class Crypt_GPG_TestCase extends PHPUnit\Framework\TestCase
 {
     // {{{ class constants
 


### PR DESCRIPTION
Make unit tests runnable with stable versions of phpunit.
Obviously this also breaks compatibility with phpunit < 6.0.

More details here in [bug #23745](https://pear.php.net/bugs/bug.php?id=23745)