### PR TITLE
Fix autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,7 @@
         "scripts/crypt-gpg-pinentry"
     ],
     "autoload": {
-        "psr-0": {
-            "Crypt": "./"
-        }
+        "classmap": ["Crypt/"]
     },
     "include-path": [
         "./"


### PR DESCRIPTION
https://github.com/pear/Crypt_GPG/blob/master/Crypt/GPG/Exceptions.php defines more than one class in a single file which violates [PSR-0](https://www.php-fig.org/psr/psr-0/). 

Therefore ["classmap"](https://getcomposer.org/doc/04-schema.md#classmap) should be used to let composer autoload the exceptions properly.

composer v1.10 started to raise a warning about this:

`Deprecation Notice: Class Crypt_GPG_Exception located in ./vendor/pear/crypt_gpg/Crypt/GPG/Exceptions.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0`