### PR TITLE
FIX: Filter non-scalar env values to prevent PHP 8.2 proc_open warnings

### DIFF
--- a/Crypt/GPG/Engine.php
+++ b/Crypt/GPG/Engine.php
@@ -1510,7 +1510,7 @@ class Crypt_GPG_Engine
                 $agentDescriptorSpec,
                 $this->_agentPipes,
                 null,
-                $env,
+                array_filter($env, 'is_scalar'),
                 array('binary_pipes' => true)
             );
 
@@ -1663,7 +1663,7 @@ class Crypt_GPG_Engine
             $descriptorSpec,
             $this->_pipes,
             null,
-            $env,
+            array_filter($env, 'is_scalar'),
             array('binary_pipes' => true)
         );
 


### PR DESCRIPTION
PHP 8.2+ throws "Array to string conversion" warning when `proc_open` receives environment variables containing non-scalar values. 
Added filtering to ensure only scalar values are passed.