### PR TITLE
Handle OpenPGP-compliant CSF message verfication

### DIFF
--- a/tests/DecryptAndVerifyTest.php
+++ b/tests/DecryptAndVerifyTest.php
@@ -939,7 +939,7 @@ TEXT;
         // }}}
 
         $results = $this->gpg->decryptAndVerify($clearsignedData);
-        $this->assertDecryptAndVerifyResultsEquals($expectedResults, $results);
+        $this->assertDecryptAndVerifyResultsEquals($expectedResults, $results, true);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -634,7 +634,7 @@ TEXT;
         return __DIR__ . '/' . self::TEMPDIR . '/' . $filename;
     }
 
-    protected function assertDecryptAndVerifyResultsEquals(array $expected, array $actual)
+    protected function assertDecryptAndVerifyResultsEquals(array $expected, array $actual, $csf = false)
     {
         $this->assertEquals(
             count($expected),
@@ -666,6 +666,11 @@ TEXT;
             'Actual result does not include signatures.'
         );
 
+        if ($csf && (substr($actual['data'], -1) != "\n")) {
+            // see discussion around GnuPG's handling of trailing
+            // newlines in CSF messages at https://dev.gnupg.org/T7106
+            $actual['data'] = $actual['data']."\n";
+        }
         $this->assertEquals(
             $expected['data'],
             $actual['data'],


### PR DESCRIPTION
GnuPG has traditionally emitted a spurious newline when outputting the text verified from a cleartext signing framework message, if the signed message doesn't contain a trailing newline.

This is clearly wrong according to the OpenPGP specification, which says:

> The line ending (i.e., the <CR><LF>) before the '-----BEGIN PGP
> SIGNATURE-----' line that terminates the signed text is not
> considered part of the signed text.

The test in Crypt_GPG presumes that the trailing newline is returned, as that has been traditional GnuPG (mis)behavior.

This change adjusts the test suite so that it passes regardless of whether GnuPG conforms to the specification or misbehaves in the traditional way.

See https://dev.gnupg.org/T7106 for discussion with upstream.

See also https://gitlab.com/freepg/gnupg/-/merge_requests/15, where the FreePG project is bringing a patched version of GnuPG into compliance with the specification.

Finally, please also see the discussion over on
https://bugs.debian.org/1099043 -- debian's GnuPG is being brought into compliance with the OpenPGP standard for CSF messages, so we need something like this to ensure that the Crypt_GPG test suite succeeds.