### PR TITLE
Key editing tool

### DIFF
--- a/Crypt/GPG.php
+++ b/Crypt/GPG.php
@@ -236,6 +236,16 @@ class Crypt_GPG extends Crypt_GPGAbstract
     protected $passphrases = [];
 
     /**
+     * Get a key editor instance
+     *
+     * @return Crypt_GPG_KeyEditor Key editor object
+     */
+    public function getKeyEditor()
+    {
+        return $this->engine->getKeyEditor();
+    }
+
+    /**
      * Imports a public or private key into the keyring
      *
      * Keys may be removed from the keyring using

--- a/Crypt/GPG/Engine.php
+++ b/Crypt/GPG/Engine.php
@@ -60,6 +60,11 @@ require_once 'Crypt/GPG/ProcessControl.php';
 require_once 'Crypt/GPG/SignatureCreationInfo.php';
 
 /**
+ * Key editor
+ */
+require_once 'Crypt/GPG/KeyEditor.php';
+
+/**
  * Standard PEAR exception is used if GPG binary is not found.
  */
 require_once 'PEAR/Exception.php';
@@ -997,6 +1002,29 @@ class Crypt_GPG_Engine
         if ($this->_processHandler) {
             $this->_processHandler->setData($name, $value);
         }
+    }
+
+    /**
+     * Initialize key editor instance
+     *
+     * @return Crypt_GPG_KeyEditor Key editor object
+     */
+    public function getKeyEditor()
+    {
+        $keys = ['homedir', 'binary', 'publicKeyring', 'privateKeyring', 'trustDb'];
+        $options = [];
+
+        foreach ($keys as $key) {
+            if (isset($this->{"_{$key}"})) {
+                $options[$key] = $this->{"_{$key}"};
+            }
+        }
+
+        if ($this->_debug) {
+            $options['debug'] = function ($line) { $this->_debug($line); };
+        }
+
+        return new Crypt_GPG_KeyEditor($this, $options);
     }
 
     /**

--- a/Crypt/GPG/Key.php
+++ b/Crypt/GPG/Key.php
@@ -108,7 +108,7 @@ class Crypt_GPG_Key
      *
      * The primary key is the first added sub-key.
      *
-     * @return Crypt_GPG_SubKey the primary sub-key of this key.
+     * @return ?Crypt_GPG_SubKey the primary sub-key of this key.
      */
     public function getPrimaryKey()
     {
@@ -166,7 +166,7 @@ class Crypt_GPG_Key
      *
      * @param Crypt_GPG_SubKey $subKey the sub-key to add.
      *
-     * @return Crypt_GPG_Key the current object, for fluent interface.
+     * @return $this the current object, for fluent interface.
      */
     public function addSubKey(Crypt_GPG_SubKey $subKey)
     {
@@ -179,7 +179,7 @@ class Crypt_GPG_Key
      *
      * @param Crypt_GPG_UserId $userId the user id to add.
      *
-     * @return Crypt_GPG_Key the current object, for fluent interface.
+     * @return $this the current object, for fluent interface.
      */
     public function addUserId(Crypt_GPG_UserId $userId)
     {

--- a/Crypt/GPG/KeyEditor.php
+++ b/Crypt/GPG/KeyEditor.php
@@ -221,6 +221,39 @@ class Crypt_GPG_KeyEditor
     }
 
     /**
+     * Set expiration date for a primary key (`expire`).
+     *
+     * @param string|int $period  Validation period: Either of:
+     *                            - 0 or an empty string for no expiration
+     *                            - <n>  - expiration in days
+     *                            - <n>w - expiration in weeks
+     *                            - <n>m - expiration in months
+     *                            - <n>y - expiration in years
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function expire($period = '')
+    {
+        if ($period === '') {
+            $period = '0';
+        }
+
+        if (!preg_match('/^[0-9]+[wmy]?$/i', (string) $period)) {
+            $this->_close();
+            throw new Crypt_GPG_Exception('Failed to set expiration. Invalid period specification.');
+        }
+
+        $handlers = [
+            'keygen.valid' => (string) $period,
+            'passphrase.enter' => $this->passphrase,
+        ];
+
+        $this->_write('expire')->_read($handlers, ['keyedit.prompt']);
+
+        return $this;
+    }
+
+    /**
      * Change a key passphrase (`passwd`).
      *
      * @param string $passphrase New passphrase

--- a/Crypt/GPG/KeyEditor.php
+++ b/Crypt/GPG/KeyEditor.php
@@ -2,7 +2,7 @@
 
 /* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
 
-require_once 'Crypt/GPG/Engine.php';
+require_once 'Crypt/GPGAbstract.php';
 
 /**
  * A class for editing keys (using GnuPG interactive --key-edit shell)
@@ -182,7 +182,12 @@ class Crypt_GPG_KeyEditor
             'passphrase.enter' => $this->passphrase,
         ];
 
-        $this->_write('adduid')->_read($handlers, ['keyedit.prompt']);
+        $output = $this->_write('adduid')->_read($handlers, ['keyedit.prompt']);
+
+        if (strpos($output, 'Need the secret key to do this')) {
+            $this->_close();
+            throw new Crypt_GPG_Exception('Failed to add a user. No secret key found.');
+        }
 
         return $this;
     }
@@ -190,11 +195,72 @@ class Crypt_GPG_KeyEditor
     /**
      * Delete a user identity from a key (`deluid`).
      *
+     * @param Crypt_GPG_UserId $userid   User identity to delete
+     * @param bool             $by_email Delete all identities with specified email address
+     *
      * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
      */
-    public function deleteUserId(Crypt_GPG_UserId $userid)
+    public function deleteUserId(Crypt_GPG_UserId $userid, $by_email = false)
     {
-        // TODO: Find the identity index (`uid 0`), call `uid X`, call `deluid`.
+        // Find the identity index (`uid 0`), call `uid X`, call `deluid`.
+        $output = $this->_write('list')->_read([], ['keyedit.prompt']);
+
+        // Process the output to find and match the user entries, and get their ids
+        $uids = [];
+        foreach (explode("\n", $output) as $line) {
+            if (preg_match('/^\[[^\]]+\]\s+\(([0-9]+)\)\.?\s+(.*)$/', $line, $matches)) {
+                $ident = Crypt_GPG_UserId::parse($matches[2]);
+                if ((string) $ident === (string) $userid || ($by_email && $ident->getEmail() === $userid->getEmail())) {
+                    $uids[] = $matches[1];
+                }
+            }
+        }
+
+        if (empty($uids)) {
+            throw new Exception("No matching users in the key.");
+        }
+
+        // We'll delete users in order where deletion does not change other IDs
+        arsort($uids, SORT_NUMERIC);
+
+        $handlers = [
+            'keyedit.remove.uid.okay' => true,
+            'passphrase.enter' => $this->passphrase,
+        ];
+
+        foreach ($uids as $uid) {
+            $this->_write("uid {$uid}")->_read($handlers, ['keyedit.prompt']);
+            $output = $this->_write('deluid')->_read($handlers, ['keyedit.prompt']);
+
+            if (strpos($output, 'You can\'t delete the last')) {
+                $this->_close();
+                throw new Crypt_GPG_Exception('Failed to delete user from a key. You can\'t delete the last user.');
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Change a key passphrase (`passwd`).
+     *
+     * @param string $passphrase New passphrase
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function passwd($passphrase)
+    {
+        // FIXME: Seems old and new pass use the same 'passphrase.enter' command
+        // What if the key has no password (or it is in cache)?
+
+        $handlers = [
+            'passphrase.enter' => [$this->passphrase, $passphrase],
+        ];
+
+        // TODO: This does not seem to work with empty passphrase
+
+        $this->_write('passwd')->_read($handlers, ['keyedit.prompt']);
+
         return $this;
     }
 
@@ -205,7 +271,7 @@ class Crypt_GPG_KeyEditor
      */
     public function quit()
     {
-        $this->_write('quit')->_read(['keyedit.save.okay' => 'N']);
+        $this->_write('quit')->_read(['keyedit.save.okay' => false]);
         $this->_close();
         return $this;
     }
@@ -238,6 +304,7 @@ class Crypt_GPG_KeyEditor
             $this->_debug("CLOSED GPG SUBPROCESS");
         }
 
+        $this->passphrase = '';
         $this->process = null;
         $this->pipes = [];
     }
@@ -247,6 +314,11 @@ class Crypt_GPG_KeyEditor
      */
     private function _read($handlers = [], $stop_at = [])
     {
+        if (empty($this->pipes[Crypt_GPG_Engine::FD_ERROR])) {
+            $this->_close();
+            throw new Crypt_GPG_Exception('The key editor output stream is closed.');
+        }
+
         $output = '';
         $passInput = false;
 
@@ -255,17 +327,18 @@ class Crypt_GPG_KeyEditor
             $outputStreams = [];
             $exceptionStreams = [];
 
-            if (!feof($this->pipes[Crypt_GPG_Engine::FD_ERROR])) {
+            if (!empty($this->pipes[Crypt_GPG_Engine::FD_ERROR]) && !feof($this->pipes[Crypt_GPG_Engine::FD_ERROR])) {
                 $inputStreams[] = $this->pipes[Crypt_GPG_Engine::FD_ERROR];
             }
 
             if (count($inputStreams) === 0) {
                 break;
             }
-            
+
             $ready = stream_select($inputStreams, $outputStreams, $exceptionStreams, null);
 
             if ($ready === false || $ready === 0) {
+                $this->_close();
                 throw new Crypt_GPG_Exception('Error selecting stream for communication with GPG subprocess');
             }
 
@@ -283,10 +356,17 @@ class Crypt_GPG_KeyEditor
                     $token = $matches[2];
 
                     if (isset($handlers[$token])) {
-                        if (is_string($handlers[$token])) {
-                            $this->_write($handlers[$token]);
-                        } elseif (is_callable($handlers[$token])) {
-                            $handlers[$token]($token, $output);
+                        $handler = $handlers[$token];
+                        if (is_array($handler)) {
+                            $handler = array_shift($handlers[$token]);
+                        }
+
+                        if (is_string($handler)) {
+                            $this->_write($handler);
+                        } elseif (is_bool($handler)) {
+                            $this->_write($handler ? 'y' : 'N');
+                        } elseif (is_callable($handler)) {
+                            $handler($token, $output);
                         }
 
                         $output = '';
@@ -316,6 +396,10 @@ class Crypt_GPG_KeyEditor
      */
     private function _write($input)
     {
+        if (empty($this->pipes[Crypt_GPG_Engine::FD_INPUT]) || feof($this->pipes[Crypt_GPG_Engine::FD_INPUT])) {
+            throw new Crypt_GPG_Exception('The key editor input stream is closed.');
+        }
+
         $this->_debug("< $input");
 
         fwrite($this->pipes[Crypt_GPG_Engine::FD_INPUT], "$input\n");

--- a/Crypt/GPG/KeyEditor.php
+++ b/Crypt/GPG/KeyEditor.php
@@ -202,33 +202,12 @@ class Crypt_GPG_KeyEditor
      */
     public function deleteUserId(Crypt_GPG_UserId $userid, $by_email = false)
     {
-        // Find the identity index (`uid 0`), call `uid X`, call `deluid`.
-        $output = $this->_write('list')->_read([], ['keyedit.prompt']);
-
-        // Process the output to find and match the user entries, and get their ids
-        $uids = [];
-        foreach (explode("\n", $output) as $line) {
-            if (preg_match('/^\[[^\]]+\]\s+\(([0-9]+)\)\.?\s+(.*)$/', $line, $matches)) {
-                $ident = Crypt_GPG_UserId::parse($matches[2]);
-                if ((string) $ident === (string) $userid || ($by_email && $ident->getEmail() === $userid->getEmail())) {
-                    $uids[] = $matches[1];
-                }
-            }
-        }
-
-        if (empty($uids)) {
-            throw new Exception("No matching users in the key.");
-        }
-
-        // We'll delete users in order where deletion does not change other IDs
-        arsort($uids, SORT_NUMERIC);
-
         $handlers = [
             'keyedit.remove.uid.okay' => true,
             'passphrase.enter' => $this->passphrase,
         ];
 
-        foreach ($uids as $uid) {
+        foreach ($this->_find_users($userid, $by_email) as $uid) {
             $this->_write("uid {$uid}")->_read($handlers, ['keyedit.prompt']);
             $output = $this->_write('deluid')->_read($handlers, ['keyedit.prompt']);
 
@@ -260,6 +239,39 @@ class Crypt_GPG_KeyEditor
         // TODO: This does not seem to work with empty passphrase
 
         $this->_write('passwd')->_read($handlers, ['keyedit.prompt']);
+
+        return $this;
+    }
+
+    /**
+     * Revoke a user identity (`revuid`).
+     *
+     * @param Crypt_GPG_UserId $userid     User identity to delete
+     * @param bool             $by_email   Delete all identities with specified email address
+     * @param bool             $is_invalid Mark the user as "no longer valid"
+     * @param string           $reason     Revocation reason description
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function revokeUserId(Crypt_GPG_UserId $userid, $by_email = false, $is_invalid = true, $reason = '')
+    {
+        $handlers = [
+            'keyedit.revoke.uid.okay' => true,
+            'ask_revocation_reason.code' => $is_invalid ? '4' : '0',
+            'ask_revocation_reason.text' => $reason,
+            'ask_revocation_reason.okay' => true,
+            'passphrase.enter' => $this->passphrase,
+        ];
+
+        foreach ($this->_find_users($userid, $by_email) as $uid) {
+            $this->_write("uid {$uid}")->_read([], ['keyedit.prompt']);
+            $output = $this->_write('revuid')->_read($handlers, ['keyedit.prompt']);
+
+            if (strpos($output, 'Cannot revoke the last valid user')) {
+                $this->_close();
+                throw new Crypt_GPG_Exception('Failed to revoke the user. You can\'t revoke the last valid user.');
+            }
+        }
 
         return $this;
     }
@@ -352,7 +364,7 @@ class Crypt_GPG_KeyEditor
 
                 $output .= $line;
 
-                if (preg_match('/(GET_LINE|GET_HIDDEN|GET_BOOL) ([a-z.]+)/', $line, $matches)) {
+                if (preg_match('/(GET_LINE|GET_HIDDEN|GET_BOOL) ([a-z._]+)/', $line, $matches)) {
                     $token = $matches[2];
 
                     if (isset($handlers[$token])) {
@@ -416,5 +428,33 @@ class Crypt_GPG_KeyEditor
         if (!empty($this->options['debug'])) {
             call_user_func($this->options['debug'], $line);
         }
+    }
+
+    /**
+     * Find user identities in the key (by full identity or email)
+     */
+    private function _find_users(Crypt_GPG_UserId $userid, $by_email = false)
+    {
+        $output = $this->_write('list')->_read([], ['keyedit.prompt']);
+
+        // Process the list output to find and match the user entries, and get their ids
+        $uids = [];
+        foreach (explode("\n", $output) as $line) {
+            if (preg_match('/^\[[^\]]+\]\s+\(([0-9]+)\)\.?\s+(.*)$/', $line, $matches)) {
+                $ident = Crypt_GPG_UserId::parse($matches[2]);
+                if ((string) $ident === (string) $userid || ($by_email && $ident->getEmail() === $userid->getEmail())) {
+                    $uids[] = $matches[1];
+                }
+            }
+        }
+
+        if (empty($uids)) {
+            throw new Crypt_GPG_Exception("No matching users in the key.");
+        }
+
+        // We'll delete users in order where deletion does not change other IDs
+        arsort($uids, SORT_NUMERIC);
+
+        return $uids;
     }
 }

--- a/Crypt/GPG/KeyEditor.php
+++ b/Crypt/GPG/KeyEditor.php
@@ -1,0 +1,336 @@
+<?php
+
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+require_once 'Crypt/GPG/Engine.php';
+
+/**
+ * A class for editing keys (using GnuPG interactive --key-edit shell)
+ *
+ * LICENSE:
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Aleksander Machniak <machniak@apheleia-it.ch>
+ * @copyright Apheleia IT AG <contact@apheleia-it.ch>
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @link      http://pear.php.net/package/Crypt_GPG
+ */
+class Crypt_GPG_KeyEditor
+{
+    /** @var array The GnuPG engine/key editor options */
+    protected $options;
+
+    /** @var Crypt_GPG_Engine The GnuPG engine */
+    protected $engine;
+
+    protected $key;
+    protected $passphrase = '';
+    protected $process;
+    protected $pipes = [];
+
+    /**
+     * Creates a new key editor
+     *
+     * @param Crypt_GPG_Engine $engine  GnuPG engine
+     * @param array            $options GnuPG engine options
+     */
+    public function __construct($engine, array $options)
+    {
+        $this->engine = $engine;
+        $this->options = $options;
+    }
+
+    /**
+     * Closes open GPG subprocesses when this object is destroyed.
+     *
+     * Subprocesses should never be left open by this class unless there is
+     * an unknown error and an unexpected script termination occured.
+     */
+    public function __destruct()
+    {
+        $this->_close();
+    }
+
+    /**
+     * Starts key editing session
+     *
+     * @param mixed  $key        The key to use. This may be a key identifier, user id, fingerprint,
+     *                           {@link Crypt_GPG_Key} or {@link Crypt_GPG_SubKey}.
+     * @param string $passphrase The passphrase of the key required for signing (optional).
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     *
+     * @sensitive $passphrase
+     */
+    public function edit($key, $passphrase = null)
+    {
+        if ($this->key && $this->process) {
+            $this->save();
+            $this->_close();
+        }
+
+        $this->key = (string) $key;
+        $this->passphrase = (string) $passphrase;
+
+        $version = $this->engine->getVersion();
+
+        // Since 2.1.13 we can use "loopback mode" instead of gpg-agent
+        // We do not support older versions here
+        if (!version_compare($version, '2.1.13', 'ge')) {
+            throw new PEAR_Exception("Key editor requires GnuPG >= 2.1.13");
+        }
+
+        $arguments = [
+            '--no-default-keyring', // ignored if keyring files are not specified
+            '--no-options',         // prevent creation of ~/.gnupg directory
+            '--no-permission-warning',
+            '--trust-model always',
+            '--homedir ' . escapeshellarg($this->options['homedir']),
+            '--pinentry-mode loopback', // passphrase input in stdin
+            '--command-fd ' . escapeshellarg(Crypt_GPG_Engine::FD_INPUT),
+            '--status-fd ' . escapeshellarg(Crypt_GPG_Engine::FD_ERROR),
+            '--batch',
+            '--yes',
+        ];
+
+        // the random seed file makes subsequent actions faster so only
+        // disable it if we have to.
+        if (!is_writeable($this->options['homedir'])) {
+            $arguments[] = '--no-random-seed-file';
+        }
+
+        if (!empty($this->options['publicKeyring'])) {
+            $arguments[] = '--keyring ' . escapeshellarg($this->options['publicKeyring']);
+        }
+
+        if (!empty($this->options['privateKeyring'])) {
+            $arguments[] = '--secret-keyring ' . escapeshellarg($this->options['privateKeyring']);
+        }
+
+        if (!empty($this->options['trustDb'])) {
+            $arguments[] = '--trustdb-name ' . escapeshellarg($this->options['trustDb']);
+        }
+
+        $command = $this->options['binary'] . ' ' . implode(' ', $arguments) . ' --edit-key ' . escapeshellarg($this->key);
+
+        $this->_debug("OPENING GPG SUBPROCESS WITH THE FOLLOWING COMMAND:");
+        $this->_debug($command);
+
+        // Get environment variables. Exclude non-scalar values to prevent from a warning in proc_open().
+        // Possibly related to https://bugs.php.net/bug.php?id=75712, which was fixed in PHP 8.2.17.
+        $env = array_filter($_ENV, 'is_scalar');
+
+        // Newer versions of GnuPG return localized results. Crypt_GPG only
+        // works with English, so set the locale to 'C' for the subprocess.
+        $env['LC_ALL'] = 'C';
+
+        $specs = [
+            Crypt_GPG_Engine::FD_INPUT => ['pipe', 'r'],
+            // Crypt_GPG_Engine::FD_OUTPUT => ['pipe', 'w'],
+            Crypt_GPG_Engine::FD_ERROR => ['pipe', 'w'],
+        ];
+
+        $this->process = proc_open($command, $specs, $this->pipes, null, $env);
+
+        if (!is_resource($this->process)) {
+            throw new Crypt_GPG_OpenSubprocessException('Unable to open GPG subprocess.', 0, $command);
+        }
+
+        // Set streams as non-blocking
+        foreach ($this->pipes as $pipe) {
+            stream_set_blocking($pipe, 0);
+            stream_set_write_buffer($pipe, 0);
+            stream_set_read_buffer($pipe, 0);
+        }
+
+        $this->_read([], ['keyedit.prompt']);
+
+        if (feof($this->pipes[Crypt_GPG_Engine::FD_ERROR])) {
+            $this->_close();
+            throw new Crypt_GPG_OpenSubprocessException('Failed to open GPG subprocess (key not found?).', 0, $command);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a user identity to a key (`adduid`).
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function addUserId(Crypt_GPG_UserId $userid)
+    {
+        $handlers = [
+            'keygen.name' => $userid->getName(),
+            'keygen.email' => $userid->getEmail(),
+            'keygen.comment' => $userid->getComment(),
+            'passphrase.enter' => $this->passphrase,
+        ];
+
+        $this->_write('adduid')->_read($handlers, ['keyedit.prompt']);
+
+        return $this;
+    }
+
+    /**
+     * Delete a user identity from a key (`deluid`).
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function deleteUserId(Crypt_GPG_UserId $userid)
+    {
+        // TODO: Find the identity index (`uid 0`), call `uid X`, call `deluid`.
+        return $this;
+    }
+
+    /**
+     * Quit the current editing session without saving changes (`quit`).
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function quit()
+    {
+        $this->_write('quit')->_read(['keyedit.save.okay' => 'N']);
+        $this->_close();
+        return $this;
+    }
+
+    /**
+     * Save the changes and exit (`save`).
+     *
+     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     */
+    public function save()
+    {
+        $this->_write('save')->_read();
+        $this->_close();
+        return $this;
+    }
+
+    /**
+     * Close the process
+     */
+    private function _close()
+    {
+        foreach ($this->pipes as $pipe) {
+            fflush($pipe);
+            fclose($pipe);
+        }
+
+        if ($this->process) {
+            proc_close($this->process);
+
+            $this->_debug("CLOSED GPG SUBPROCESS");
+        }
+
+        $this->process = null;
+        $this->pipes = [];
+    }
+
+    /**
+     * Read process output
+     */
+    private function _read($handlers = [], $stop_at = [])
+    {
+        $output = '';
+        $passInput = false;
+
+        while (true) {
+            $inputStreams = [];
+            $outputStreams = [];
+            $exceptionStreams = [];
+
+            if (!feof($this->pipes[Crypt_GPG_Engine::FD_ERROR])) {
+                $inputStreams[] = $this->pipes[Crypt_GPG_Engine::FD_ERROR];
+            }
+
+            if (count($inputStreams) === 0) {
+                break;
+            }
+            
+            $ready = stream_select($inputStreams, $outputStreams, $exceptionStreams, null);
+
+            if ($ready === false || $ready === 0) {
+                throw new Crypt_GPG_Exception('Error selecting stream for communication with GPG subprocess');
+            }
+
+            if (in_array($this->pipes[Crypt_GPG_Engine::FD_ERROR], $inputStreams, true)) {
+                $line = fgets($this->pipes[Crypt_GPG_Engine::FD_ERROR], 8192);
+                if ($line === false) {
+                    break;
+                }
+
+                $this->_debug(rtrim("> $line"));
+
+                $output .= $line;
+
+                if (preg_match('/(GET_LINE|GET_HIDDEN|GET_BOOL) ([a-z.]+)/', $line, $matches)) {
+                    $token = $matches[2];
+
+                    if (isset($handlers[$token])) {
+                        if (is_string($handlers[$token])) {
+                            $this->_write($handlers[$token]);
+                        } elseif (is_callable($handlers[$token])) {
+                            $handlers[$token]($token, $output);
+                        }
+
+                        $output = '';
+                    }
+
+                    if (in_array($token, $stop_at)) {
+                        break;
+                    }
+
+                    $passInput = $token == 'passphrase.enter';
+                }
+
+                if ($passInput && strpos($line, 'Bad passphrase')) {
+                    $this->_close();
+                    throw new  Crypt_GPG_BadPassphraseException('Missing or wrong key passphrase');
+                }
+            }
+
+            usleep(10);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Write to the process input
+     */
+    private function _write($input)
+    {
+        $this->_debug("< $input");
+
+        fwrite($this->pipes[Crypt_GPG_Engine::FD_INPUT], "$input\n");
+        fflush($this->pipes[Crypt_GPG_Engine::FD_INPUT]);
+
+        return $this;
+    }
+
+    /**
+     * Log debug information
+     */
+    private function _debug($line)
+    {
+        if (!empty($this->options['debug'])) {
+            call_user_func($this->options['debug'], $line);
+        }
+    }
+}

--- a/Crypt/GPG/KeyEditor.php
+++ b/Crypt/GPG/KeyEditor.php
@@ -73,7 +73,7 @@ class Crypt_GPG_KeyEditor
      *                           {@link Crypt_GPG_Key} or {@link Crypt_GPG_SubKey}.
      * @param string $passphrase The passphrase of the key required for signing (optional).
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      *
      * @sensitive $passphrase
      */
@@ -171,7 +171,7 @@ class Crypt_GPG_KeyEditor
     /**
      * Add a user identity to a key (`adduid`).
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function addUserId(Crypt_GPG_UserId $userid)
     {
@@ -198,7 +198,7 @@ class Crypt_GPG_KeyEditor
      * @param Crypt_GPG_UserId $userid   User identity to delete
      * @param bool             $by_email Delete all identities with specified email address
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function deleteUserId(Crypt_GPG_UserId $userid, $by_email = false)
     {
@@ -230,7 +230,7 @@ class Crypt_GPG_KeyEditor
      *                            - <n>m - expiration in months
      *                            - <n>y - expiration in years
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function expire($period = '')
     {
@@ -258,7 +258,7 @@ class Crypt_GPG_KeyEditor
      *
      * @param string $passphrase New passphrase
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function passwd($passphrase)
     {
@@ -284,7 +284,7 @@ class Crypt_GPG_KeyEditor
      * @param bool             $is_invalid Mark the user as "no longer valid"
      * @param string           $reason     Revocation reason description
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function revokeUserId(Crypt_GPG_UserId $userid, $by_email = false, $is_invalid = true, $reason = '')
     {
@@ -312,7 +312,7 @@ class Crypt_GPG_KeyEditor
     /**
      * Quit the current editing session without saving changes (`quit`).
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function quit()
     {
@@ -324,7 +324,7 @@ class Crypt_GPG_KeyEditor
     /**
      * Save the changes and exit (`save`).
      *
-     * @return Crypt_GPG_KeyEditor The current object, for fluent interface.
+     * @return $this The current object, for fluent interface.
      */
     public function save()
     {

--- a/tests/KeyEditorTest.php
+++ b/tests/KeyEditorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * KeyEditor class test cases for the Crypt_GPG package.
+ *
+ * LICENSE:
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Aleksander Machniak <machniak@apheleia-it.ch>
+ * @copyright Apheleia IT AG <contact@apheleia-it.ch>
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @link      http://pear.php.net/package/Crypt_GPG
+ */
+
+require_once 'TestCase.php';
+require_once 'Crypt/GPG/Key.php';
+require_once 'Crypt/GPG/UserId.php';
+require_once 'Crypt/GPG/SubKey.php';
+require_once 'Crypt/GPG/KeyEditor.php';
+
+/**
+ * KeyEditor class tests for Crypt_GPG.
+ *
+ * @category  Encryption
+ * @package   Crypt_GPG
+ * @author    Aleksander Machniak <machniak@apheleia-it.ch>
+ * @copyright Apheleia IT AG <contact@apheleia-it.ch>
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ * @link      http://pear.php.net/package/Crypt_GPG
+ */
+class KeyEditorTest extends Crypt_GPG_TestCase
+{
+    /**
+     * Test unknown key
+     */
+    public function testUnknownKey()
+    {
+        $this->expectException('Crypt_GPG_OpenSubprocessException');
+
+        $keyEditor = $this->gpg->getKeyEditor();
+        $keyEditor->edit('unknown@example.com', 'test');
+    }
+
+    /**
+     * Test `adduid` command
+     */
+    public function testAddUserId()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
+
+        // Test successful user addition
+        $user = new Crypt_GPG_UserId([
+            'name'    => 'Alice',
+            'comment' => 'shipping',
+            'email'   => 'alice@example.com'
+        ]);
+
+        $keyEditor->edit('first-keypair@example.com', 'test1')
+            ->addUserId($user)
+            ->save();
+
+        $keys = $this->gpg->getKeys('first-keypair@example.com');
+
+        $userIds = $keys[0]->getUserIds();
+        $this->assertCount(2, $userIds);
+
+        $userIds = array_filter($userIds, function ($id) use ($user) { return $id->getName() == $user->getName(); });
+        $this->assertCount(1, $userIds);
+
+        $userId = $userIds[key($userIds)];
+        $this->assertSame($user->getEmail(), $userId->getEmail());
+        $this->assertSame($user->getComment(), $userId->getComment());
+
+        // Test that `quit` does not save.
+        $user = new Crypt_GPG_UserId([
+            'name'    => 'Alice2',
+            'comment' => '',
+            'email'   => 'alice2@example.com'
+        ]);
+
+        $keyEditor->edit('first-keypair@example.com', 'test1')
+            ->addUserId($user)
+            ->quit();
+
+        $keys = $this->gpg->getKeys('first-keypair@example.com');
+
+        $userIds = $keys[0]->getUserIds();
+        $this->assertCount(2, $userIds);
+
+        $userIds = array_filter($userIds, function ($id) use ($user) { return $id->getName() == $user->getName(); });
+        $this->assertCount(0, $userIds);
+
+        // Test invalid password
+        $this->expectException('Crypt_GPG_BadPassphraseException');
+        $keyEditor->edit('second-keypair@example.com', 'wrong')
+            ->addUserId($user)
+            ->save();
+    }
+
+    /**
+     * Test `deluid` command
+     */
+    public function testDeleteUserId()
+    {
+        $this->markTestIncomplete();
+    }
+}

--- a/tests/KeyEditorTest.php
+++ b/tests/KeyEditorTest.php
@@ -170,8 +170,14 @@ class KeyEditorTest extends Crypt_GPG_TestCase
         $user = new Crypt_GPG_UserId('Second Keypair Test Key (do not encrypt important data with this key) <second-keypair@example.com>');
         $this->expectException('Crypt_GPG_Exception');
         $keyEditor->edit('second-keypair@example.com', 'test2')->deleteUserId($user)->save();
+    }
 
-        // Test deleting the last user
+    /**
+     * Test `deluid` command with a non-existing user
+     */
+    public function testDeleteUserIdUnknown()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
         $user = new Crypt_GPG_UserId('<unknown-keypair@example.com>');
         $this->expectException('Crypt_GPG_Exception');
         $keyEditor->edit('second-keypair@example.com', 'test2')->deleteUserId($user)->save();
@@ -191,5 +197,44 @@ class KeyEditorTest extends Crypt_GPG_TestCase
             ->save();
 
         $this->assertTrue(true);
+    }
+
+    /**
+     * Test `revuid` command
+     */
+    public function testRevokeUserId()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
+
+        // First add some users to the key
+        $user1 = (new Crypt_GPG_UserId())->setEmail('alice@example.com');
+
+        // Add the user to revoke
+        $keyEditor->edit('second-keypair@example.com', 'test2')->addUserId($user1)->save();
+
+        // Test deleting user with name, comment and email
+        $keyEditor->edit('second-keypair@example.com', 'test2')->revokeUserId($user1)->save();
+
+        $keys = $this->gpg->getKeys('second-keypair@example.com');
+        $userIds = $keys[0]->getUserIds();
+        $this->assertCount(2, $userIds);
+        $userIds = array_filter($userIds, function ($id) use ($user1) { return $id->getEmail() == $user1->getEmail(); });
+        $this->assertCount(1, $userIds);
+
+        // Test revoking the last user
+        $user = new Crypt_GPG_UserId('Second Keypair Test Key (do not encrypt important data with this key) <second-keypair@example.com>');
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('second-keypair@example.com', 'test2')->revokeUserId($user)->save();
+    }
+
+    /**
+     * Test `revuid` command with a non-existing user
+     */
+    public function testRevokeUserIdUnknown()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
+        $user = new Crypt_GPG_UserId('<unknown-keypair@example.com>');
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('second-keypair@example.com', 'test2')->revokeUserId($user)->save();
     }
 }

--- a/tests/KeyEditorTest.php
+++ b/tests/KeyEditorTest.php
@@ -184,6 +184,32 @@ class KeyEditorTest extends Crypt_GPG_TestCase
     }
 
     /**
+     * Test `expire` command
+     */
+    public function testExpire()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
+
+        // Test setting an expiration date (one year from today)
+        $keyEditor->edit('second-keypair@example.com', 'test2')->expire('1y')->save();
+
+        $keys = $this->gpg->getKeys('second-keypair@example.com');
+        $primary = $keys[0]->getPrimaryKey();
+        $this->assertSame((date('Y') + 1) . date('-m-d'), $primary->getExpirationDateTime()->format('Y-m-d'));
+
+        // Test unsetting an expiration date
+        $keyEditor->edit('second-keypair@example.com', 'test2')->expire(0)->save();
+
+        $keys = $this->gpg->getKeys('second-keypair@example.com');
+        $primary = $keys[0]->getPrimaryKey();
+        $this->assertNull($primary->getExpirationDateTime());
+
+        // Test invalid period
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('second-keypair@example.com', 'test2')->expire('-1')->save();
+    }
+
+    /**
      * Test `passwd` command
      */
     public function testPasswd()
@@ -218,8 +244,9 @@ class KeyEditorTest extends Crypt_GPG_TestCase
         $keys = $this->gpg->getKeys('second-keypair@example.com');
         $userIds = $keys[0]->getUserIds();
         $this->assertCount(2, $userIds);
-        $userIds = array_filter($userIds, function ($id) use ($user1) { return $id->getEmail() == $user1->getEmail(); });
+        $userIds = array_values(array_filter($userIds, function ($id) use ($user1) { return $id->getEmail() == $user1->getEmail(); }));
         $this->assertCount(1, $userIds);
+        $this->assertTrue($userIds[0]->isRevoked());
 
         // Test revoking the last user
         $user = new Crypt_GPG_UserId('Second Keypair Test Key (do not encrypt important data with this key) <second-keypair@example.com>');

--- a/tests/KeyEditorTest.php
+++ b/tests/KeyEditorTest.php
@@ -30,9 +30,6 @@
  */
 
 require_once 'TestCase.php';
-require_once 'Crypt/GPG/Key.php';
-require_once 'Crypt/GPG/UserId.php';
-require_once 'Crypt/GPG/SubKey.php';
 require_once 'Crypt/GPG/KeyEditor.php';
 
 /**
@@ -107,11 +104,13 @@ class KeyEditorTest extends Crypt_GPG_TestCase
         $userIds = array_filter($userIds, function ($id) use ($user) { return $id->getName() == $user->getName(); });
         $this->assertCount(0, $userIds);
 
+        // Test editing a key that has no secret key
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('public-only@example.com', 'test')->addUserId($user)->save();
+
         // Test invalid password
         $this->expectException('Crypt_GPG_BadPassphraseException');
-        $keyEditor->edit('second-keypair@example.com', 'wrong')
-            ->addUserId($user)
-            ->save();
+        $keyEditor->edit('second-keypair@example.com', 'wrong')->addUserId($user)->save();
     }
 
     /**
@@ -119,6 +118,78 @@ class KeyEditorTest extends Crypt_GPG_TestCase
      */
     public function testDeleteUserId()
     {
-        $this->markTestIncomplete();
+        $keyEditor = $this->gpg->getKeyEditor();
+
+        // First add some users to the key
+        $user1 = new Crypt_GPG_UserId([
+            'name'    => 'Alice',
+            'comment' => 'shipping',
+            'email'   => 'alice@example.com'
+        ]);
+
+        $user2 = new Crypt_GPG_UserId([
+            'name'    => 'John',
+            'comment' => '',
+            'email'   => 'john@example.com'
+        ]);
+
+        $user3 = new Crypt_GPG_UserId([
+            'name'    => '',
+            'comment' => '',
+            'email'   => 'john@example.com'
+        ]);
+
+        $keyEditor->edit('second-keypair@example.com', 'test2')
+            ->addUserId($user1)
+            ->addUserId($user2)
+            ->addUserId($user3)
+            ->save();
+
+        // Test deleting user with name, comment and email
+        $keyEditor->edit('second-keypair@example.com', 'test2')->deleteUserId($user1)->save();
+
+        $keys = $this->gpg->getKeys('second-keypair@example.com');
+        $userIds = $keys[0]->getUserIds();
+        $this->assertCount(3, $userIds);
+        $userIds = array_filter($userIds, function ($id) use ($user1) { return $id->getEmail() != $user1->getEmail(); });
+        $this->assertCount(3, $userIds);
+
+        // Test deleting users with no name or no comment
+        $keyEditor->edit('second-keypair@example.com', 'test2')
+            ->deleteUserId($user2)
+            ->deleteUserId($user3)
+            ->save();
+
+        $keys = $this->gpg->getKeys('second-keypair@example.com');
+        $userIds = $keys[0]->getUserIds();
+        $this->assertCount(1, $userIds);
+        $userIds = array_filter($userIds, function ($id) use ($user1) { return $id->getEmail() != $user1->getEmail(); });
+        $this->assertCount(1, $userIds);
+
+        // Test deleting the last user
+        $user = new Crypt_GPG_UserId('Second Keypair Test Key (do not encrypt important data with this key) <second-keypair@example.com>');
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('second-keypair@example.com', 'test2')->deleteUserId($user)->save();
+
+        // Test deleting the last user
+        $user = new Crypt_GPG_UserId('<unknown-keypair@example.com>');
+        $this->expectException('Crypt_GPG_Exception');
+        $keyEditor->edit('second-keypair@example.com', 'test2')->deleteUserId($user)->save();
+    }
+
+    /**
+     * Test `passwd` command
+     */
+    public function testPasswd()
+    {
+        $keyEditor = $this->gpg->getKeyEditor();
+        $keyEditor->edit('first-keypair@example.com', 'test1')->passwd('new pass')->save();
+
+        // Assert the new password in fact works
+        $keyEditor->edit('first-keypair@example.com', 'new pass')
+            ->addUserId($user = new Crypt_GPG_UserId('alice@example.com'))
+            ->save();
+
+        $this->assertTrue(true);
     }
 }


### PR DESCRIPTION
Implements a way to use the interactive `gpg --key-edit` console. Not all commands available in there are implemented yet, but I think the engine is good enough for a release. We can call it experimental if we have to.